### PR TITLE
Updated the facade method hint with the missing argument

### DIFF
--- a/src/VerificationCode.php
+++ b/src/VerificationCode.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static \NextApps\VerificationCode\VerificationCodeManager send(string $verifiable, string $channel = 'mail')
- * @method static \NextApps\VerificationCode\VerificationCodeManager verify(string $code, string $verifiable)
+ * @method static \NextApps\VerificationCode\VerificationCodeManager verify(string $code, string $verifiable, bool $deleteAfterVerification = true)
  *
  * @see \NextApps\VerificationCode\VerificationCodeManager
  */


### PR DESCRIPTION
Because the original has a `bool $deleteAfterVerification = true` argument, which I was surprised that it wasn't suggested by the IDE, so I thought it was deprecated or something! 